### PR TITLE
Fixing the namespace of the visitor class

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -178,4 +178,4 @@ vgl.visitor = function() {
 
   return this;
 }
-inherit(visitor, vgl.object);
+inherit(vgl.visitor, vgl.object);


### PR DESCRIPTION
A tiny change fixing the visitor class if it ever gets included in the build source.  I noticed this doing some analysis of the class hierarchy.
