### PR TITLE
Do not set resetScene flag to true if children = 0

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -475,11 +475,6 @@ vgl.renderer = function() {
   this.removeActor = function(actor) {
     if (m_sceneRoot.children().indexOf(actor) !== -1) {
       m_sceneRoot.removeChild(actor);
-
-      if (m_sceneRoot.children().length === 0) {
-        m_resetScene = true;
-      }
-
       this.modified();
       return true;
     }


### PR DESCRIPTION
This does not make sense in a dynamic environement. As we remove
actors from the scene, we just want the same old camera position
most of the time.
