### PR TITLE
Changes to allow dynamically changing source data.

### DIFF
--- a/src/geomData.js
+++ b/src/geomData.js
@@ -351,7 +351,7 @@ vgl.sourceData = function(arg) {
   arg = arg || {};
   var m_attributesMap = {},
       m_data = [],
-      m_name = arg.name || "Source " + (new Date).toISOString(),
+      m_name = arg.name || "Source " + new Date().toISOString(),
 
       ////////////////////////////////////////////////////////////////////////////
       /**

--- a/src/geomData.js
+++ b/src/geomData.js
@@ -341,16 +341,17 @@ vgl.vertexDataP3T3f = function() {
  * @returns {vgl.sourceData}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceData = function() {
+vgl.sourceData = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceData)) {
-    return new vgl.sourceData();
+    return new vgl.sourceData(arg);
   }
 
+  arg = arg || {};
   var m_attributesMap = {},
       m_data = [],
-      m_name = "",
+      m_name = arg.name || "Source " + (new Date).toISOString(),
 
       ////////////////////////////////////////////////////////////////////////////
       /**
@@ -647,12 +648,12 @@ vgl.sourceData = function() {
 };
 
 
-vgl.sourceDataAnyfv = function(size, key) {
+vgl.sourceDataAnyfv = function(size, key, arg) {
   if (!(this instanceof vgl.sourceDataAnyfv)) {
-      return new vgl.sourceDataAnyfv(size, key);
+      return new vgl.sourceDataAnyfv(size, key, arg);
     }
 
-    vgl.sourceData.call(this);
+    vgl.sourceData.call(this, arg);
     this.addAttribute(key, gl.FLOAT,
                       4, 0, size * 4, size, false);
 
@@ -671,13 +672,13 @@ inherit(vgl.sourceDataAnyfv, vgl.sourceData);
  * @returns {vgl.sourceDataP3T3f}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceDataP3T3f = function() {
+vgl.sourceDataP3T3f = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceDataP3T3f)) {
-    return new vgl.sourceDataP3T3f();
+    return new vgl.sourceDataP3T3f(arg);
   }
-  vgl.sourceData.call(this);
+  vgl.sourceData.call(this, arg);
 
   this.addAttribute(vgl.vertexAttributeKeys.Position, gl.FLOAT, 4, 0, 6 * 4, 3,
                     false);
@@ -701,14 +702,14 @@ inherit(vgl.sourceDataP3T3f, vgl.sourceData);
  * @returns {vgl.sourceDataP3N3f}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceDataP3N3f = function() {
+vgl.sourceDataP3N3f = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceDataP3N3f)) {
-    return new vgl.sourceDataP3N3f();
+    return new vgl.sourceDataP3N3f(arg);
   }
 
-  vgl.sourceData.call(this);
+  vgl.sourceData.call(this, arg);
 
   this.addAttribute(vgl.vertexAttributeKeys.Position, gl.FLOAT, 4, 0, 6 * 4, 3,
                     false);
@@ -732,14 +733,14 @@ inherit(vgl.sourceDataP3N3f, vgl.sourceData);
  * @returns {vgl.sourceDataP3fv}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceDataP3fv = function() {
+vgl.sourceDataP3fv = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceDataP3fv)) {
-    return new vgl.sourceDataP3fv();
+    return new vgl.sourceDataP3fv(arg);
   }
 
-  vgl.sourceData.call(this);
+  vgl.sourceData.call(this, arg);
 
   this.addAttribute(vgl.vertexAttributeKeys.Position, gl.FLOAT, 4, 0, 3 * 4, 3,
                     false);
@@ -760,14 +761,14 @@ inherit(vgl.sourceDataP3fv, vgl.sourceData);
  * @returns {vgl.sourceDataT2fv}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceDataT2fv = function() {
+vgl.sourceDataT2fv = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceDataT2fv)) {
-    return new vgl.sourceDataT2fv();
+    return new vgl.sourceDataT2fv(arg);
   }
 
-  vgl.sourceData.call(this);
+  vgl.sourceData.call(this, arg);
 
   this.addAttribute(vgl.vertexAttributeKeys.TextureCoordinate, gl.FLOAT, 4, 0,
                     2 * 4, 2, false);
@@ -788,14 +789,14 @@ inherit(vgl.sourceDataT2fv, vgl.sourceData);
  * @returns {vgl.sourceDataC3fv}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceDataC3fv = function() {
+vgl.sourceDataC3fv = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceDataC3fv)) {
-    return new vgl.sourceDataC3fv();
+    return new vgl.sourceDataC3fv(arg);
   }
 
-  vgl.sourceData.call(this);
+  vgl.sourceData.call(this, arg);
 
   this.addAttribute(vgl.vertexAttributeKeys.Color, gl.FLOAT, 4, 0, 3 * 4, 3, false);
 
@@ -816,11 +817,11 @@ inherit(vgl.sourceDataC3fv, vgl.sourceData);
  * @returns {vgl.sourceDataSf}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceDataSf = function() {
+vgl.sourceDataSf = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceDataSf)) {
-    return new vgl.sourceDataSf();
+    return new vgl.sourceDataSf(arg);
   }
 
   var m_min = null,
@@ -828,7 +829,7 @@ vgl.sourceDataSf = function() {
       m_fixedmin = null,
       m_fixedmax = null;
 
-  vgl.sourceData.call(this);
+  vgl.sourceData.call(this, arg);
 
   this.addAttribute(vgl.vertexAttributeKeys.Scalar, gl.FLOAT, 4, 0, 4, 1, false);
 
@@ -884,11 +885,11 @@ inherit(vgl.sourceDataSf, vgl.sourceData);
  * @returns {vgl.sourceDataDf}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.sourceDataDf = function() {
+vgl.sourceDataDf = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.sourceDataDf)) {
-    return new vgl.sourceDataDf();
+    return new vgl.sourceDataDf(arg);
   }
 
   var m_min = null,
@@ -896,7 +897,7 @@ vgl.sourceDataDf = function() {
       m_fixedmin = null,
       m_fixedmax = null;
 
-  vgl.sourceData.call(this);
+  vgl.sourceData.call(this, arg);
 
   this.addAttribute(vgl.vertexAttributeKeys.Scalar, gl.FLOAT,
                     4, 0, 4, 1, false);

--- a/src/geomData.js
+++ b/src/geomData.js
@@ -350,6 +350,7 @@ vgl.sourceData = function() {
 
   var m_attributesMap = {},
       m_data = [],
+      m_name = "",
 
       ////////////////////////////////////////////////////////////////////////////
       /**
@@ -622,6 +623,25 @@ vgl.sourceData = function() {
       }
     }
   };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Return name of the source data
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.name = function() {
+    return m_name;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Set name of the source data
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.setName = function(name) {
+    m_name = name;
+  };
+
 
   return this;
 };
@@ -950,9 +970,12 @@ vgl.geometryData = function() {
    * Add new source
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.addSource = function(source) {
+  this.addSource = function(source, sourceName) {
     // @todo Check if the incoming source has duplicate keys
 
+    if (sourceName !== undefined) {
+        source.setName(sourceName);
+    }
     // NOTE This might not work on IE8 or lower
     if (m_sources.indexOf(source) === -1) {
       m_sources.push(source);


### PR DESCRIPTION
Added names to sources.

Added a 'dynamicDraw' flag to the mapper.  If this is set, then the webGL buffers are created with gl.DYNAMIC_DRAW and can be changed.

Added an mapper.updateSourceBuffer method that can update the data of a named source.  If a Float32Array is passed in, no memory allocation is performed.

This is related to issue #66.