### PR TITLE
Pass args to mapper class creation.

### DIFF
--- a/src/mapper.js
+++ b/src/mapper.js
@@ -21,7 +21,7 @@ vgl.mapper = function(arg) {
   'use strict';
 
   if (!(this instanceof vgl.mapper)) {
-    return new vgl.mapper();
+    return new vgl.mapper(arg);
   }
   vgl.boundingObject.call(this);
 


### PR DESCRIPTION
We were passing arguments to the mapper function, but these weren't passed on to the class creation.