### PR TITLE
Change how memory is allocated.

### DIFF
--- a/src/DataBuffers.js
+++ b/src/DataBuffers.js
@@ -27,6 +27,12 @@ vgl.DataBuffers = function (initialSize) {
 
     var resize = function (min_expand) {
         var new_size = size;
+        /* If the array would increase substantially, don't just double its
+         * size.  If the array has been increasing gradually, double it as the
+         * expectation is that it will increase again. */
+        if (new_size * 2 < min_expand) {
+            new_size = min_expand;
+        }
         while (new_size < min_expand)
             new_size *= 2;
         size = new_size;


### PR DESCRIPTION
We were always allocating a power of two of the initial data buffer size.  This is inefficient for large arrays, so if the size is increased significantly in one call, just allocate the amount that was asked for.