### PR TITLE
Copy buffers less and access buffers directly.

### DIFF
--- a/src/geomData.js
+++ b/src/geomData.js
@@ -406,7 +406,7 @@ vgl.sourceData = function(arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.dataToFloat32Array = function () {
-    if (Object.prototype.toString.call(m_data) !== "[object Float32Array]") {
+    if (!(m_data instanceof Float32Array)) {
       m_data = new Float32Array(m_data);
     }
     return m_data;
@@ -620,9 +620,8 @@ vgl.sourceData = function(arg) {
 
     //m_data = m_data.concat(data); //no, slow on Safari
     /* If we will are given a Float32Array and don't have any other data, use
-     * it directly */
-    if (!m_data.length && data.length &&
-        Object.prototype.toString.call(data) === "[object Float32Array]") {
+     * it directly. */
+    if (!m_data.length && data.length && data instanceof Float32Array) {
       m_data = data;
       return;
     }

--- a/src/geomData.js
+++ b/src/geomData.js
@@ -379,7 +379,7 @@ vgl.sourceData = function(arg) {
   /**
    * Return raw data for this source
    *
-   * @returns {Array}
+   * @returns {Array or Float32Array}
    */
   ////////////////////////////////////////////////////////////////////////////
   this.data = function() {
@@ -390,11 +390,26 @@ vgl.sourceData = function(arg) {
  /**
    * Return raw data for this source
    *
-   * @returns {Array}
+   * @returns {Array or Float32Array}
    */
   ////////////////////////////////////////////////////////////////////////////
   this.getData = function() {
     return data();
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * If the raw data is not a Float32Array, convert it to one.  Then, return
+   * raw data for this source
+   *
+   * @returns {Float32Array}
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.dataToFloat32Array = function () {
+    if (Object.prototype.toString.call(m_data) !== "[object Float32Array]") {
+      m_data = new Float32Array(m_data);
+    }
+    return m_data;
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -604,11 +619,30 @@ vgl.sourceData = function(arg) {
     var i;
 
     //m_data = m_data.concat(data); //no, slow on Safari
+    /* If we will are given a Float32Array and don't have any other data, use
+     * it directly */
+    if (!m_data.length && data.length &&
+        Object.prototype.toString.call(data) === "[object Float32Array]") {
+      m_data = data;
+      return;
+    }
+    /* If our internal array is immutable and we will need to change it, create
+     * a regular mutable array from it. */
+    if (!m_data.slice && (m_data.length || !data.slice)) {
+      m_data = Array.prototype.slice.call(m_data);
+    }
     if (!data.length) {
+      /* data is a singular value, so append it to our array */
       m_data[m_data.length] = data;
     } else {
-      for (i = 0; i < data.length; i++) {
-        m_data[m_data.length] = data[i];
+      /* We don't have any data currently, so it is faster to copy the data
+       * using slice. */
+      if (!m_data.length && data.slice) {
+        m_data = data.slice(0);
+      } else {
+        for (i = 0; i < data.length; i++) {
+          m_data[m_data.length] = data[i];
+        }
       }
     }
   };

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -66,7 +66,7 @@ vgl.mapper = function(arg) {
         bufferId = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, bufferId);
         data = m_geomData.source(i).data();
-        if (Object.prototype.toString.call(data) !== '[object Float32Array]') {
+        if (!(data instanceof Float32Array)) {
           data = new Float32Array(data);
         }
         gl.bufferData(gl.ARRAY_BUFFER, data,
@@ -226,7 +226,7 @@ vgl.mapper = function(arg) {
       values = m_geomData.source(i).dataToFloat32Array();
     }
     gl.bindBuffer(gl.ARRAY_BUFFER, m_buffers[bufferIndex]);
-    if (Object.prototype.toString.call(values) === '[object Float32Array]') {
+    if (values instanceof Float32Array) {
       gl.bufferSubData(gl.ARRAY_BUFFER, 0, values);
     } else {
       gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(values));

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -60,14 +60,17 @@ vgl.mapper = function(arg) {
   function createVertexBufferObjects() {
     if (m_geomData) {
       var numberOfSources = m_geomData.numberOfSources(),
-          i, j, k, bufferId = null, keys, ks, numberOfPrimitives;
+          i, j, k, bufferId = null, keys, ks, numberOfPrimitives, data;
 
       for (i = 0; i < numberOfSources; ++i) {
         bufferId = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, bufferId);
-        gl.bufferData(gl.ARRAY_BUFFER,
-          new Float32Array(m_geomData.source(i).data()),
-                           m_dynamicDraw ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
+        data = m_geomData.source(i).data();
+        if (Object.prototype.toString.call(data) !== '[object Float32Array]') {
+          data = new Float32Array(data);
+        }
+        gl.bufferData(gl.ARRAY_BUFFER, data,
+                      m_dynamicDraw ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
 
         keys = m_geomData.source(i).keys();
         ks = [];
@@ -204,7 +207,8 @@ vgl.mapper = function(arg) {
    * Update the buffer used for a named source.
    *
    * @param {String} sourceName The name of the source to update.
-   * @param {Object[] or Float32Array} vakues The values to use for the source.
+   * @param {Object[] or Float32Array} values The values to use for the source.
+   *    If not specified, use the source's own buffer.
    */
   ////////////////////////////////////////////////////////////////////////////
   this.updateSourceBuffer = function (sourceName, values) {
@@ -215,16 +219,44 @@ vgl.mapper = function(arg) {
         break;
       }
     }
-    if (bufferIndex < 0 || bufferIndex >= m_buffers.lengh) {
-        return false;
+    if (bufferIndex < 0 || bufferIndex >= m_buffers.length) {
+      return false;
+    }
+    if (!values) {
+      values = m_geomData.source(i).dataToFloat32Array();
     }
     gl.bindBuffer(gl.ARRAY_BUFFER, m_buffers[bufferIndex]);
-    if (Object.prototype.toString.call(values) === "[object Float32Array]") {
-        gl.bufferSubData(gl.ARRAY_BUFFER, 0, values);
+    if (Object.prototype.toString.call(values) === '[object Float32Array]') {
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, values);
     } else {
-        gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(values));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(values));
     }
     return true;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Get the buffer used for a named source.  If the current buffer isn't a
+   * Float32Array, it is converted to one.  This array can then be modified
+   * directly, after which updateSourceBuffer can be called to update the
+   * GL array.
+   *
+   * @param {String} sourceName The name of the source to update.
+   * @returns {Float32Array} An array used for this source.
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.getSourceBuffer = function (sourceName) {
+    var bufferIndex = -1;
+    for (var i = 0; i < m_geomData.numberOfSources(); i += 1) {
+      if (m_geomData.source(i).name() === sourceName) {
+        bufferIndex = i;
+        break;
+      }
+    }
+    if (bufferIndex < 0 || bufferIndex >= m_buffers.length) {
+      return new Float32Array();
+    }
+    return m_geomData.source(i).dataToFloat32Array();
   };
 
   ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
For the common use case of a source using a single array of data, take steps to avoid copying that data.  Prior to this change, when a source was set, a data buffer with a Float32Array was allocated for it.  This data buffer would then be inserted into the source, which internally would copy the Float32Array to a javascript array using a for loop.  Later, when the vertex buffer objects were created, the javascript array would be copied to a Float32Array.

Instead, if the source is not mutated, use the original Float32Array data buffer for the entire process.

This speeds up creation of data points in a test case by a factor of 3 (from an average time of 3.3 seconds down to 1.1 seconds for 300,000 points).

Additionally, the mapper object can return the internal Float32Array used for any source with a new getSourceBuffer method.  If this array is altered and dynamicDraw is turned on, then calling updateSourceBuffer without a data array will just reuse the source's internal Float32Array.  In this way, a calling program dos not need to create such an array itself.