### PR TITLE
Better buffer and source access, improved speed

### DIFF
--- a/src/DataBuffers.js
+++ b/src/DataBuffers.js
@@ -6,7 +6,7 @@ vgl.DataBuffers = function (initialSize) {
     var data = {};
 
     var size;
-    if (!initialSize)
+    if (!initialSize && initialSize !== 0)
         size = 256;
     else
         size = initialSize;
@@ -54,6 +54,7 @@ vgl.DataBuffers = function (initialSize) {
             len: len,
             dirty: false
         };
+        return data[name].array;
     };
 
     this.alloc = function (num) {

--- a/src/geomData.js
+++ b/src/geomData.js
@@ -1151,11 +1151,9 @@ vgl.geometryData = function() {
           offset = sourceData.attributeOffset(attr),
           sizeOfDataType = sourceData.sizeOfAttributeDataType(attr),
           count = data.length,
-          ib = 0,
-          jb = 0,
+          j, ib, jb, maxv, minv,
           value = null,
-          vertexIndex,
-          j;
+          vertexIndex;
 
       // We advance by index, not by byte
       stride /= sizeOfDataType;
@@ -1163,24 +1161,25 @@ vgl.geometryData = function() {
 
       this.resetBounds();
 
-      for (vertexIndex = offset; vertexIndex < count; vertexIndex += stride) {
-        for (j = 0; j < numberOfComponents; ++j) {
-          value = data[vertexIndex + j];
-          ib = j * 2;
-          jb = j * 2 + 1;
-
-          if (vertexIndex === offset) {
-            m_bounds[ib] = value;
-            m_bounds[jb] = value;
-          } else {
-            if (value > m_bounds[jb]) {
-              m_bounds[jb] = value;
-            }
-            if (value < m_bounds[ib]) {
-              m_bounds[ib] = value;
-            }
+      for (j = 0; j < numberOfComponents; ++j) {
+        ib = j * 2;
+        jb = j * 2 + 1;
+        if (count) {
+          maxv = minv = m_bounds[jb] = data[offset];
+        } else {
+          maxv = minv = 0;
+        }
+        for (vertexIndex = offset + stride + j; vertexIndex < count;
+             vertexIndex += stride) {
+          value = data[vertexIndex];
+          if (value > maxv) {
+            maxv = value;
+          }
+          if (value < minv) {
+            minv = value;
           }
         }
+        m_bounds[ib] = minv;  m_bounds[jb] = maxv;
       }
 
       m_computeBoundsTimestamp.modified();

--- a/src/geomData.js
+++ b/src/geomData.js
@@ -418,12 +418,16 @@ vgl.sourceData = function(arg) {
    *
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.setData = function(data) {
-    if (!(data instanceof Array)) {
+  this.setData = function (data) {
+    if (!(data instanceof Array) && !(data instanceof Float32Array)) {
       console.log("[error] Requires array");
       return;
     }
-    m_data = data.slice(0);
+    if (data instanceof Float32Array) {
+      m_data = data;
+    } else {
+      m_data = data.slice(0);
+    }
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1038,6 +1042,20 @@ vgl.geometryData = function() {
 
   ////////////////////////////////////////////////////////////////////////////
   /**
+   * Return source with a specified name.  Returns 0 if not found.
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.sourceByName = function (sourceName) {
+    for (var i = 0; i < m_sources.length; i += 1) {
+      if (m_sources[i].name() === sourceName) {
+        return m_sources[i];
+      }
+    }
+    return 0;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
    * Return number of sources
    */
   ////////////////////////////////////////////////////////////////////////////
@@ -1102,6 +1120,21 @@ vgl.geometryData = function() {
       this.computeBounds();
     }
     return m_bounds;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Check if bounds are dirty or mark them as such.
+   *
+   * @param dirty: true to set bounds as dirty.
+   * Return true if bounds are dirty.
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.boundsDirty = function (dirty) {
+    if (dirty) {
+      m_boundsDirtyTimestamp.modified();
+    }
+    return m_boundsDirtyTimestamp.getMTime() > m_computeBoundsTimestamp.getMTime();
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -246,17 +246,11 @@ vgl.mapper = function(arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.getSourceBuffer = function (sourceName) {
-    var bufferIndex = -1;
-    for (var i = 0; i < m_geomData.numberOfSources(); i += 1) {
-      if (m_geomData.source(i).name() === sourceName) {
-        bufferIndex = i;
-        break;
-      }
-    }
-    if (bufferIndex < 0 || bufferIndex >= m_buffers.length) {
+    var source = m_geomData.sourceByName(sourceName);
+    if (!source) {
       return new Float32Array();
     }
-    return m_geomData.source(i).dataToFloat32Array();
+    return source.dataToFloat32Array();
   };
 
   ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a variety of access methods and a speed improvement.  They are necessary for the speed improvements in geojs.

Optimized computeBounds.  This reduces the average load time in a test I am running by around 6 or 7%.

Return the data buffer array upon creation so a second call to buffers.data() isn't necessary.

Expose marking a source as dirty via a public method.

Allow setting the source data with a Flot32Array directly.

Get a source by name.