### PR TITLE
Use pre-blended alpha and simpler blending.

### DIFF
--- a/src/blend.js
+++ b/src/blend.js
@@ -6,7 +6,7 @@
 /*jslint devel: true, forin: true, newcap: true, plusplus: true*/
 /*jslint white: true, continue:true, indent: 2*/
 
-/*global vgl, gl, ogs, vec4, inherit, $*/
+/*global vgl, gl, inherit */
 //////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
@@ -19,7 +19,7 @@
  * @returns {vgl.blendFunction}
  */
 //////////////////////////////////////////////////////////////////////////////
-vgl.blendFunction = function(source, destination) {
+vgl.blendFunction = function (source, destination) {
   'use strict';
 
   if (!(this instanceof vgl.blendFunction)) {
@@ -37,8 +37,13 @@ vgl.blendFunction = function(source, destination) {
    * @param {vgl.renderState}
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.apply = function(renderState) {
-    gl.blendFuncSeparate(m_source, m_destination, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+  this.apply = function (renderState) {
+    /* For post-blending alpha, use the blendFuncSeparate call.  However, some
+     * comptuers (notably MacBook Pros) don't accelerate blendFuncSeparate,
+     * so it is often faster to use pre-blended alpha.
+     * gl.blendFuncSeparate(m_source, m_destination, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+     */
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
   };
 
   return this;
@@ -51,7 +56,7 @@ vgl.blendFunction = function(source, destination) {
  * @returns {vgl.blend}
  */
 ////////////////////////////////////////////////////////////////////////////
-vgl.blend = function() {
+vgl.blend = function () {
   'use strict';
 
   if (!(this instanceof vgl.blend)) {
@@ -72,14 +77,13 @@ vgl.blend = function() {
    * @param {vgl.renderState}
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.bind = function(renderState) {
+  this.bind = function (renderState) {
     m_wasEnabled = gl.isEnabled(gl.BLEND);
 
     if (this.enabled()) {
       gl.enable(gl.BLEND);
       m_blendFunction.apply(renderState);
-    }
-    else {
+    } else {
       gl.disable(gl.BLEND);
     }
 
@@ -93,11 +97,10 @@ vgl.blend = function() {
    * @param {vgl.renderState}
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.undoBind = function(renderState) {
+  this.undoBind = function (renderState) {
     if (m_wasEnabled) {
       gl.enable(gl.BLEND);
-    }
-    else {
+    } else {
       gl.disable(gl.BLEND);
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,7 +97,7 @@ vgl.utils.createTextureFragmentShader = function(context) {
         'uniform sampler2D sampler2d;',
         'uniform mediump float opacity;',
         'void main(void) {',
-        'gl_FragColor = vec4(texture2D(sampler2d, vec2(iTextureCoord.s, iTextureCoord.t)).xyz, opacity);',
+        'gl_FragColor = vec4(texture2D(sampler2d, vec2(iTextureCoord.s, iTextureCoord.t)).xyz * opacity, opacity);',
         '}' ].join('\n'),
       shader = new vgl.shader(gl.FRAGMENT_SHADER);
 
@@ -123,8 +123,7 @@ vgl.utils.createRgbaTextureFragmentShader = function (context) {
         'uniform mediump float opacity;',
         'void main(void) {',
         '  mediump vec4 color = vec4(texture2D(sampler2d, vec2(iTextureCoord.s, iTextureCoord.t)).xyzw);',
-        '  color.w *= opacity;',
-        '  gl_FragColor = color;',
+        '  gl_FragColor = vec4(color.rgb * color.a, color.a) * opacity;',
         '}'
       ].join('\n'),
       shader = new vgl.shader(gl.FRAGMENT_SHADER);
@@ -272,7 +271,7 @@ vgl.utils.createFragmentShader = function(context) {
   var fragmentShaderSource = [ 'varying mediump vec3 iVertexColor;',
                               'uniform mediump float opacity;',
                               'void main(void) {',
-                              'gl_FragColor = vec4(iVertexColor, opacity);',
+                              'gl_FragColor = vec4(iVertexColor * opacity, opacity);',
                               '}' ].join('\n'),
       shader = new vgl.shader(gl.FRAGMENT_SHADER);
 
@@ -382,7 +381,7 @@ vgl.utils.createFragmentShaderSolidColor = function(context, color) {
   'use strict';
   var fragmentShaderSource = ['uniform mediump float opacity;',
                               'void main(void) {',
-                              'gl_FragColor = vec4(' + color[0] + ',' + color[1] + ',' + color[2] + ', opacity);',
+                              'gl_FragColor = vec4(vec3(' + color[0] + ',' + color[1] + ',' + color[2] + ') * opacity, opacity);',
                               '}' ].join('\n'),
       shader = new vgl.shader(gl.FRAGMENT_SHADER);
 
@@ -407,7 +406,7 @@ vgl.utils.createFragmentShaderColorMap = function(context) {
         'uniform sampler2D sampler2d;',
         'uniform mediump float opacity;',
         'void main(void) {',
-        'gl_FragColor = vec4(texture2D(sampler2d, vec2(iVertexScalar, 0.0)).xyz, opacity);',
+        'gl_FragColor = vec4(texture2D(sampler2d, vec2(iVertexScalar, 0.0)).xyz * opacity, opacity);',
         '}' ].join('\n'),
       shader = new vgl.shader(gl.FRAGMENT_SHADER);
 
@@ -482,11 +481,11 @@ vgl.utils.createPointSpritesFragmentShader = function(context) {
         '}',
         'highp float texOpacity = texture2D(opacityLookup, realTexCoord).w;',
         'if (useScalarsToColors == 1) {',
-        '  gl_FragColor = vec4(texture2D(scalarsToColors, vec2((iVertexScalar - lutMin)/(lutMax - lutMin), 0.0)).xyz, texOpacity);',
+        '  gl_FragColor = vec4(texture2D(scalarsToColors, vec2((iVertexScalar - lutMin)/(lutMax - lutMin), 0.0)).xyz * texOpacity, texOpacity);',
         '} else if (useVertexColors == 1) {',
-        '  gl_FragColor = vec4(iVertexColor, texOpacity);',
+        '  gl_FragColor = vec4(iVertexColor * texOpacity, texOpacity);',
         '} else {',
-        '  gl_FragColor = vec4(texture2D(opacityLookup, realTexCoord).xyz, texOpacity);',
+        '  gl_FragColor = vec4(texture2D(opacityLookup, realTexCoord).xyz * texOpacity, texOpacity);',
         '}}'
     ].join('\n'),
     shader = new vgl.shader(gl.FRAGMENT_SHADER);


### PR DESCRIPTION
For post-blending alpha, we need to use the blendFuncSeparate call.  However,
some computers (notably MacBook Pros) don't accelerate blendFuncSeparate, so it
is faster on those machines to use pre-blended alpha.