### PR TITLE
Fixed a typo that could cause problems later.

### DIFF
--- a/src/uniform.js
+++ b/src/uniform.js
@@ -39,7 +39,7 @@ vgl.uniform = function(type, name) {
 
       case gl.FLOAT_VEC3:
       case gl.INT_VEC3:
-      case gl.BOOLT_VEC3:
+      case gl.BOOL_VEC3:
         return 3;
 
       case gl.FLOAT_VEC4:


### PR DESCRIPTION
There is no such thing as `gl.BOOLT_VEC3`, it is `gl.BOOL_VEC3`.