### PR TITLE
Clear cached shaders when exiting from a renderWindow.

### DIFF
--- a/src/renderWindow.js
+++ b/src/renderWindow.js
@@ -294,6 +294,7 @@ vgl.renderWindow = function (canvas) {
     for (i = 0; i < m_renderers.length; i += 1) {
       m_renderers[i]._cleanup(renderState);
     }
+    vgl.clearCachedShaders();
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/renderWindow.js
+++ b/src/renderWindow.js
@@ -294,7 +294,7 @@ vgl.renderWindow = function (canvas) {
     for (i = 0; i < m_renderers.length; i += 1) {
       m_renderers[i]._cleanup(renderState);
     }
-    vgl.clearCachedShaders();
+    vgl.clearCachedShaders(renderState ? renderState.m_context : null);
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/shader.js
+++ b/src/shader.js
@@ -167,9 +167,18 @@ inherit(vgl.shader, vgl.object);
   /////////////////////////////////////////////////////////////////////////////
   /**
    * Clear the shader cache.
+   *
+   * @param context the GL context to clear, or null for clear all.
    */
   /////////////////////////////////////////////////////////////////////////////
-  vgl.clearCachedShaders = function () {
-    m_shaderCache.splice(0, m_shaderCache.length);
+  vgl.clearCachedShaders = function (context) {
+    console.log(context, m_shaderCache, m_shaderCache.length);
+    for (var i = m_shaderCache.length - 1; i >= 0; i -= 1) {
+      if (context === null || context === undefined ||
+          m_shaderCache[i].context === context) {
+        m_shaderCache.splice(i, 1);
+      }
+    }
+    console.log(context, m_shaderCache, m_shaderCache.length);
   };
 })();

--- a/src/shader.js
+++ b/src/shader.js
@@ -172,13 +172,11 @@ inherit(vgl.shader, vgl.object);
    */
   /////////////////////////////////////////////////////////////////////////////
   vgl.clearCachedShaders = function (context) {
-    console.log(context, m_shaderCache, m_shaderCache.length);
     for (var i = m_shaderCache.length - 1; i >= 0; i -= 1) {
       if (context === null || context === undefined ||
           m_shaderCache[i].context === context) {
         m_shaderCache.splice(i, 1);
       }
     }
-    console.log(context, m_shaderCache, m_shaderCache.length);
   };
 })();

--- a/src/shader.js
+++ b/src/shader.js
@@ -163,4 +163,13 @@ inherit(vgl.shader, vgl.object);
     }
     return shader;
   };
+
+  /////////////////////////////////////////////////////////////////////////////
+  /**
+   * Clear the shader cache.
+   */
+  /////////////////////////////////////////////////////////////////////////////
+  vgl.clearCachedShaders = function () {
+    m_shaderCache.splice(0, m_shaderCache.length);
+  };
 })();


### PR DESCRIPTION
After exiting a renderWindow, a context can be reused.  In this case, clear the shader cache so as to prevent trying to use a shader that is no longer present.