### PR TITLE
Keep more precision in model view origins.

### DIFF
--- a/src/uniform.js
+++ b/src/uniform.js
@@ -3,7 +3,7 @@
  * @module vgl
  */
 
-/*global vgl, mat4, vec3, inherit*/
+/*global vgl, mat4, inherit*/
 //////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -248,7 +248,7 @@ vgl.modelViewOriginUniform = function (name, origin) {
     name = 'modelViewMatrix';
   }
 
-  var m_origin = vec3.fromValues(origin[0], origin[1], origin[2]);
+  var m_origin = [origin[0], origin[1], origin[2] || 0];
 
   vgl.uniform.call(this, vgl.GL.FLOAT_MAT4, name);
 


### PR DESCRIPTION
We have a special uniform called modelViewOriginUniform which offsets a model view matrix by an origin.  This is intended to reduce the GL computation error.  The origin was being stored in a vec3, which internally uses a GLMAT_ARRAY_TYPE, which, in turn, is a Float32Array.  This loses precision needlessly, as the origin doesn't get passed into WebGL but does get applied as a translation to the view matrix.  By using a native javascript array, the precision is maintained at whatever is initially supplied.