### PR TITLE
Allow setting the camera view matrix as a specific datatype.

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -425,10 +425,16 @@ vgl.camera = function (arg) {
    * it won't be recomputed unless something else changes.
    *
    * @param {mat4} view: new view matrix.
+   * @param {boolean} preserveType: if true, clone the input using slice.  This
+   *    can be used to ensure the array is a specific precision.
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.setViewMatrix = function (view) {
-    mat4.copy(m_viewMatrix, view);
+  this.setViewMatrix = function (view, preserveType) {
+    if (!preserveType) {
+      mat4.copy(m_viewMatrix, view);
+    } else {
+      m_viewMatrix = view.slice();
+    }
     m_computeModelViewMatrixTime.modified();
   };
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -266,8 +266,14 @@ vgl.renderer = function (arg) {
       actor = sortedActors[i][1];
       if (actor.referenceFrame() ===
           vgl.boundingObject.ReferenceFrame.Relative) {
-        mat4.multiply(renSt.m_modelViewMatrix, m_this.m_camera.viewMatrix(),
-          actor.matrix());
+        var view = m_this.m_camera.viewMatrix();
+        /* If the view matrix is a plain array, keep it as such.  This is
+         * intended to preserve precision, and will only be the case if the
+         * view matrix was created by delibrately setting it as an array. */
+        if (view instanceof Array) {
+          renSt.m_modelViewMatrix = new Array(16);
+        }
+        mat4.multiply(renSt.m_modelViewMatrix, view, actor.matrix());
         renSt.m_projectionMatrix = m_this.m_camera.projectionMatrix();
         renSt.m_modelViewAlignment = m_this.m_camera.viewAlignment();
       } else {


### PR DESCRIPTION
Instead of always converting the camera view matrix into a mat4, allow keeping it as whatever type is provided.  If this is done, preserve that datatype as long as possible.  This helps avoid precision issues.