### PR TITLE
Clean up VBOs when we remove actors.

### DIFF
--- a/src/mapper.js
+++ b/src/mapper.js
@@ -32,21 +32,26 @@ vgl.mapper = function (arg) {
       m_bufferVertexAttributeMap = {},
       m_dynamicDraw = arg.dynamicDraw === undefined ? false : arg.dynamicDraw,
       m_glCompileTimestamp = vgl.timestamp(),
-      m_context = null;
+      m_context = null,
+      m_this = this;
 
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Delete cached VBO if any
-   *
-   * @private
    */
   ////////////////////////////////////////////////////////////////////////////
-  function deleteVertexBufferObjects(renderState) {
+  this.deleteVertexBufferObjects = function (renderState) {
     var i;
-    for (i = 0; i < m_buffers.length; i += 1) {
-      renderState.m_context.deleteBuffer(m_buffers[i]);
+    var context = m_context;
+    if (renderState) {
+      context = renderState.m_context;
     }
-  }
+    if (context) {
+      for (i = 0; i < m_buffers.length; i += 1) {
+        context.deleteBuffer(m_buffers[i]);
+      }
+    }
+  };
 
   ////////////////////////////////////////////////////////////////////////////
   /**
@@ -121,7 +126,7 @@ vgl.mapper = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   function setupDrawObjects(renderState) {
     // Delete buffer objects from past if any.
-    deleteVertexBufferObjects(renderState);
+    m_this.deleteVertexBufferObjects(renderState);
 
     // Clear any cache related to buffers
     cleanUpDrawObjects(renderState);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -203,7 +203,9 @@ vgl.renderer = function (arg) {
     renSt = new vgl.renderState();
     renSt.m_renderer = m_this;
     renSt.m_context = m_this.renderWindow().context();
-    m_this.m_depthBits = renSt.m_context.getParameter(vgl.GL.DEPTH_BITS);
+    if (!m_this.m_depthBits || m_this.m_contextChanged) {
+      m_this.m_depthBits = renSt.m_context.getParameter(vgl.GL.DEPTH_BITS);
+    }
     renSt.m_contextChanged = m_this.m_contextChanged;
 
     if (m_this.m_renderPasses) {
@@ -558,6 +560,12 @@ vgl.renderer = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   this.removeActor = function (actor) {
     if (m_this.m_sceneRoot.children().indexOf(actor) !== -1) {
+      /* When we remove an actor, free the VBOs of the mapper and mark the
+       * mapper as modified; it will reallocate VBOs as necessary. */
+      if (actor.mapper()) {
+        actor.mapper().deleteVertexBufferObjects();
+        actor.mapper().modified();
+      }
       m_this.m_sceneRoot.removeChild(actor);
       m_this.modified();
       return true;


### PR DESCRIPTION
Eventually, we will run out of Vertex Buffer Objects.  Now, it is possible for the GPU to reuse them.  Some sources cite that it is poor practice to allocated and deallocate VBOs (though much better than never deallocating them), and it would be better to maintain a reference to them and reuse them instead.

Also, cache the depthBits parameter.  Getting WebGL parameters takes some time, and if we know they haven't changed, we can cache the values to get a minor speed improvement.