### PR TITLE
Allow a shader program to be associated with multiple contexts.

### DIFF
--- a/src/shaderProgram.js
+++ b/src/shaderProgram.js
@@ -288,8 +288,9 @@ vgl.shaderProgram = function () {
   this.deleteVertexAndFragment = function (renderState) {
     var i;
     for (i = 0; i < m_shaders.length; i += 1) {
-      renderState.m_context.detachShader(m_shaders[i].shaderHandle());
-      renderState.m_context.deleteShader(m_shaders[i].shaderHandle());
+      renderState.m_context.detachShader(m_shaders[i].shaderHandle(renderState));
+      renderState.m_context.deleteShader(m_shaders[i].shaderHandle(renderState));
+      m_shaders[i].removeContext(renderState);
     }
   };
 


### PR DESCRIPTION
Each context is compiled and attached separately.  These are tracked in an internal array, and are only compiled as required.

I've confirmed the multipleMaps test works with this change.