### PR TITLE
Unbind vertex data

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
         "key-spacing": 0,
         "no-unneeded-ternary": 0,
         "yoda": 0,
-        "no-useless-call": 0
+        "no-useless-call": 0,
+        "camelcase": 0
     },
     "env": {
         "browser": true,

--- a/src/material.js
+++ b/src/material.js
@@ -295,7 +295,7 @@ vgl.material = function () {
 
     for (i in m_attributes) {
       if (m_attributes.hasOwnProperty(i)) {
-        m_attributes.undoBindVertexData(renderState, key);
+        m_attributes[i].undoBindVertexData(renderState, key);
       }
     }
   };

--- a/src/material.js
+++ b/src/material.js
@@ -62,11 +62,10 @@ vgl.material = function () {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.exists = function (attr) {
-    if (attr.type() === vgl.materialAttribute.Texture) {
-      return m_textureAttributes.hasOwnProperty(attr);
+    if (attr.type() === vgl.materialAttributeType.Texture) {
+      return m_textureAttributes.hasOwnProperty(attr.textureUnit());
     }
-
-    return m_attributes.hasOwnProperty(attr);
+    return m_attributes.hasOwnProperty(attr.type());
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -78,28 +77,25 @@ vgl.material = function () {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.uniform = function (name) {
-    if (m_shaderProgram) {
-      return m_shaderProgram.uniform(name);
-    }
-
-    return null;
+    return m_shaderProgram ? m_shaderProgram.uniform(name) : null;
   };
 
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Get material attribute
 
-   * @param attr Attribute name
+   * @param {number} type attribute type
+   * @param {number} textureUnit attribute texture unit if type is Texture.
    * @returns {vgl.materialAttribute}
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.attribute = function (name) {
-    if (m_attributes.hasOwnProperty(name)) {
-      return m_attributes[name];
+  this.attribute = function (type, textureUnit) {
+    if (m_attributes.hasOwnProperty(type)) {
+      return m_attributes[type];
     }
 
-    if (m_textureAttributes.hasOwnProperty(name)) {
-      return m_textureAttributes[name];
+    if (type === vgl.materialAttributeType.Texture && m_textureAttributes.hasOwnProperty(textureUnit)) {
+      return m_textureAttributes[textureUnit];
     }
 
     return null;
@@ -117,8 +113,10 @@ vgl.material = function () {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.setAttribute = function (attr) {
-    if (attr.type() === vgl.materialAttributeType.Texture &&
-        m_textureAttributes[attr.textureUnit()] !== attr) {
+    if (attr.type() === vgl.materialAttributeType.Texture) {
+      if (m_textureAttributes[attr.textureUnit()] === attr) {
+        return false;
+      }
       m_textureAttributes[attr.textureUnit()] = attr;
       m_this.modified();
       return true;
@@ -189,7 +187,7 @@ vgl.material = function () {
    */
   ////////////////////////////////////////////////////////////////////////////
   this._setup = function (renderState) {
-    renderState = renderState; /* unused parameter */
+    void renderState; /* unused parameter */
     return false;
   };
 

--- a/src/shaderProgram.js
+++ b/src/shaderProgram.js
@@ -56,18 +56,21 @@ vgl.shaderProgram = function () {
    */
   /////////////////////////////////////////////////////////////////////////////
   this.loadFromFile = function (type, sourceUrl) {
-    var shader;
+    var shader, success = false;
     $.ajax({
       url: sourceUrl,
       type: 'GET',
+      dataType: 'text',
       async: false,
       success: function (result) {
         //console.log(result);
         shader = vgl.shader(type);
         shader.setShaderSource(result);
         m_this.addShader(shader);
+        success = true;
       }
     });
+    return success;
   };
 
   /////////////////////////////////////////////////////////////////////////////
@@ -77,7 +80,7 @@ vgl.shaderProgram = function () {
    */
   /////////////////////////////////////////////////////////////////////////////
   this.loadShader = function (type, file) {
-    this.loadFromFile(type, getBaseUrl() + '/shaders/' + file);
+    return this.loadFromFile(type, getBaseUrl() + '/shaders/' + file);
   };
 
   /////////////////////////////////////////////////////////////////////////////
@@ -118,9 +121,9 @@ vgl.shaderProgram = function () {
     }
 
     var i;
-    for (i = 0; i < m_shaders.length; i += 1) {
+    for (i = m_shaders.length - 2; i >= 0; i -= 1) {
       if (m_shaders[i].shaderType() === shader.shaderType()) {
-        m_shaders.splice(m_shaders.indexOf(shader), 1);
+        m_shaders.splice(i, 1);
       }
     }
 
@@ -144,6 +147,7 @@ vgl.shaderProgram = function () {
 
     m_uniforms.push(uniform);
     m_this.modified();
+    return true;
   };
 
   /////////////////////////////////////////////////////////////////////////////
@@ -281,6 +285,7 @@ vgl.shaderProgram = function () {
   /////////////////////////////////////////////////////////////////////////////
   this.deleteProgram = function (renderState) {
     renderState.m_context.deleteProgram(m_programHandle);
+    m_programHandle = 0;
   };
 
   /////////////////////////////////////////////////////////////////////////////

--- a/testing/cases/phantomjs/mapper.js
+++ b/testing/cases/phantomjs/mapper.js
@@ -1,0 +1,139 @@
+/* global describe, it, expect, vgl, mockVGLRenderer */
+
+describe('vgl.mapper', function () {
+  describe('Create', function () {
+    it('create function', function () {
+      var map = vgl.mapper();
+      expect(map instanceof vgl.mapper).toBe(true);
+      map = vgl.mapper({dynamicDraw: true});
+      expect(map instanceof vgl.mapper).toBe(true);
+    });
+  });
+  describe('Public methods', function () {
+    var mapper, renderState, glCounts;
+    it('computeBounds', function () {
+      mockVGLRenderer();
+      mapper = vgl.mapper();
+      var viewer = vgl.viewer($('<canvas/>')[0]);
+      viewer.init();
+      var renderer = viewer.renderWindow().activeRenderer(),
+          material = vgl.material(),
+          geom = vgl.geometryData(),
+          data = vgl.vertexAttribute('data'),
+          prog = material.shaderProgram(),
+          sourceData = vgl.sourceDataAnyfv(
+            2, vgl.vertexAttributeKeysIndexed.One, {'name': 'data'});
+      prog.addVertexAttribute(data, vgl.vertexAttributeKeysIndexed.One);
+      material.addAttribute(prog);
+      geom.addSource(sourceData);
+      mapper.computeBounds();
+      mapper.setGeometryData(geom);
+      renderState = new vgl.renderState();
+      renderState.m_renderer = renderer;
+      renderState.m_context = renderer.renderWindow().context();
+      renderState.m_mapper = mapper;
+      renderState.m_material = material;
+      expect(mapper.bounds()[0]).toBe(Number.MAX_VALUE);
+      expect(mapper.bounds()[5]).toBe(-Number.MAX_VALUE);
+      mapper.computeBounds();
+      expect(mapper.bounds()).toEqual([0, 0, 0, 0, 0, 0]);
+      mapper.setGeometryData(null);
+      mapper.computeBounds();
+      expect(mapper.bounds()[0]).toBe(Number.MAX_VALUE);
+      expect(mapper.bounds()[5]).toBe(-Number.MAX_VALUE);
+      mapper.setGeometryData(geom);
+    });
+    it('color and setColor', function () {
+      expect(mapper.color()).toEqual([0, 1, 1]);
+      mapper.setColor(0.5, 0.25, 0.1);
+      expect(mapper.color()).toEqual([0.5, 0.25, 0.1]);
+    });
+    it('geometryData and setGeometryData', function () {
+      var geom1 = vgl.geometryData(),
+          geom2 = vgl.geometryData(),
+          lasttime;
+      lasttime = mapper.getMTime();
+      mapper.setGeometryData(geom1);
+      expect(mapper.geometryData()).toBe(geom1);
+      expect(mapper.getMTime()).toBeGreaterThan(lasttime);
+      lasttime = mapper.getMTime();
+      mapper.setGeometryData(geom1);
+      expect(mapper.geometryData()).toBe(geom1);
+      expect(mapper.getMTime()).toBe(lasttime);
+      mapper.setGeometryData(geom2);
+      expect(mapper.geometryData()).toBe(geom2);
+      expect(mapper.getMTime()).toBeGreaterThan(lasttime);
+    });
+    it('getSourceBuffer', function () {
+      mapper.geometryData().addSource(vgl.sourceDataAnyfv(
+            2, vgl.vertexAttributeKeysIndexed.One, {'name': 'source1'}));
+      expect(mapper.getSourceBuffer('source1') instanceof Float32Array).toBe(true);
+      expect(mapper.getSourceBuffer('not a source') instanceof Float32Array).toBe(true);
+    });
+    it('updateSourceBuffer', function () {
+      expect(mapper.updateSourceBuffer()).toBe(false);
+      expect(mapper.updateSourceBuffer('not a source', [], renderState)).toBe(false);
+      mapper.render(renderState);
+      expect(mapper.updateSourceBuffer('source1', undefined, renderState)).toBe(true);
+      var src1 = new Float32Array([1, 1, 2, 3, 5, 8, 13, 21]);
+      glCounts = $.extend({}, vgl.mockCounts());
+      expect(mapper.updateSourceBuffer('source1', src1, renderState)).toBe(true);
+      expect(vgl.mockCounts().bufferSubData).toBe((glCounts.bufferSubData || 0) + 1);
+      glCounts = $.extend({}, vgl.mockCounts());
+      expect(mapper.updateSourceBuffer('source1', [1, 1, 2, 3, 5, 8, 13, 21], renderState)).toBe(true);
+      expect(vgl.mockCounts().bufferSubData).toBe((glCounts.bufferSubData || 0) + 1);
+    });
+    it('render and undoBindVertexData', function () {
+      var triStrip = new vgl.triangleStrip(),
+          tri = new vgl.triangles(),
+          lineStrip = new vgl.lineStrip(),
+          line = new vgl.lines(),
+          point = new vgl.points(),
+          src2 = vgl.sourceDataAnyfv(
+            2, vgl.vertexAttributeKeysIndexed.One, {'name': 'source1'});
+      triStrip.setIndices([0, 1, 2, 3, 4, 5, 6, 7]);
+      tri.setIndices([0, 1, 2, 3, 4, 5, 6, 7]);
+      lineStrip.setIndices([0, 1, 2, 3, 4, 5, 6, 7]);
+      line.setIndices([0, 1, 2, 3, 4, 5, 6, 7]);
+      point.setIndices([0, 1, 2, 3, 4, 5, 6, 7]);
+      mapper.geometryData().addPrimitive(triStrip);
+      glCounts = $.extend({}, vgl.mockCounts());
+      mapper.modified();
+      mapper.render(renderState);
+      expect(vgl.mockCounts().drawArrays).toBe((glCounts.drawArrays || 0) + 1);
+
+      mapper.geometryData().addPrimitive(tri);
+      glCounts = $.extend({}, vgl.mockCounts());
+      mapper.modified();
+      mapper.render(renderState);
+      expect(vgl.mockCounts().drawArrays).toBe((glCounts.drawArrays || 0) + 2);
+
+      mapper.geometryData().addPrimitive(lineStrip);
+      mapper.geometryData().addPrimitive(line);
+      mapper.geometryData().addPrimitive(point);
+      glCounts = $.extend({}, vgl.mockCounts());
+      mapper.modified();
+      mapper.render(renderState);
+      expect(vgl.mockCounts().drawArrays).toBe((glCounts.drawArrays || 0) + 5);
+
+      glCounts = $.extend({}, vgl.mockCounts());
+      mapper.render(renderState);
+      expect(vgl.mockCounts().disableVertexAttribArray).toBe((glCounts.disableVertexAttribArray || 0) + 1);
+      mapper.render(renderState, true);
+      expect(vgl.mockCounts().disableVertexAttribArray).toBe((glCounts.disableVertexAttribArray || 0) + 1);
+      mapper.undoBindVertexData(renderState);
+      expect(vgl.mockCounts().disableVertexAttribArray).toBe((glCounts.disableVertexAttribArray || 0) + 2);
+
+      src2.setData([0, 1, 2, 3]);  // not Float32Array
+      mapper.geometryData().addSource(src2);
+      mapper.modified();
+      mapper.render(renderState);
+    });
+    it('deleteVertexBufferObjects', function () {
+      mapper.render(renderState);
+      glCounts = $.extend({}, vgl.mockCounts());
+      mapper.deleteVertexBufferObjects(renderState);
+      expect(vgl.mockCounts().deleteBuffer).toBe((glCounts.deleteBuffer || 0) + 7);
+    });
+  });
+});

--- a/testing/cases/phantomjs/material.js
+++ b/testing/cases/phantomjs/material.js
@@ -1,0 +1,147 @@
+/* global describe, it, expect, vgl, mockVGLRenderer */
+
+describe('vgl.material', function () {
+  describe('Create', function () {
+    it('create function', function () {
+      var mat = vgl.material();
+      expect(mat instanceof vgl.material).toBe(true);
+    });
+  });
+  describe('Public methods', function () {
+    var mat, renderState, glCounts;
+    it('binNumber and setBinNumber', function () {
+      mat = vgl.material();
+      expect(mat.binNumber()).toBe(100);
+      var lasttime = mat.getMTime();
+      mat.setBinNumber(vgl.material.RenderBin.Transparent);
+      expect(mat.getMTime()).toBeGreaterThan(lasttime);
+      expect(mat.binNumber()).toBe(1000);
+    });
+    it('addAttribute, exists, attribute, setAttribute, and shaderProgram', function () {
+      var blend1 = new vgl.blend(),
+          blend2 = new vgl.blend(),
+          tex1 = new vgl.texture(),
+          tex2 = new vgl.texture(),
+          prog1 = new vgl.shaderProgram(),
+          prog2 = new vgl.shaderProgram();
+      expect(mat.attribute(vgl.materialAttributeType.Blend)).toBe(null);
+      expect(mat.exists(blend1)).toBe(false);
+      expect(mat.addAttribute(blend1)).toBe(true);
+      expect(mat.attribute(vgl.materialAttributeType.Blend)).toBe(blend1);
+      expect(mat.exists(blend1)).toBe(true);
+      expect(mat.addAttribute(blend1)).toBe(false);
+      expect(mat.addAttribute(blend2)).toBe(false);
+      expect(mat.attribute(vgl.materialAttributeType.Blend)).toBe(blend1);
+      expect(mat.setAttribute(blend2)).toBe(true);
+      expect(mat.attribute(vgl.materialAttributeType.Blend)).toBe(blend2);
+      expect(mat.setAttribute(blend2)).toBe(false);
+      expect(mat.attribute(vgl.materialAttributeType.Blend)).toBe(blend2);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 0)).toBe(null);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 1)).toBe(null);
+      expect(mat.exists(tex1)).toBe(false);
+      expect(mat.addAttribute(tex1)).toBe(true);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 0)).toBe(tex1);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 1)).toBe(null);
+      expect(mat.exists(tex1)).toBe(true);
+      expect(mat.addAttribute(tex1)).toBe(false);
+      expect(mat.setAttribute(tex2)).toBe(true);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 0)).toBe(tex2);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 1)).toBe(null);
+      expect(mat.setAttribute(tex2)).toBe(false);
+      tex1.setTextureUnit(1);
+      expect(mat.setAttribute(tex1)).toBe(true);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 0)).toBe(tex2);
+      expect(mat.attribute(vgl.materialAttributeType.Texture, 1)).toBe(tex1);
+      /* Even though there is a default shader program, it isn't listed in the
+       * attributes.  New shader programs are, though. */
+      expect(mat.shaderProgram()).not.toBe(null);
+      expect(mat.exists(mat.shaderProgram())).toBe(false);
+      expect(mat.attribute(vgl.materialAttributeType.ShaderProgram)).toBe(null);
+      expect(mat.addAttribute(prog1)).toBe(true);
+      expect(mat.exists(prog1)).toBe(true);
+      expect(mat.attribute(vgl.materialAttributeType.ShaderProgram)).toBe(prog1);
+      expect(mat.addAttribute(prog1)).toBe(false);
+      expect(mat.attribute(vgl.materialAttributeType.ShaderProgram)).toBe(prog1);
+      expect(mat.setAttribute(prog2)).toBe(true);
+      expect(mat.attribute(vgl.materialAttributeType.ShaderProgram)).toBe(prog2);
+      expect(mat.shaderProgram()).toBe(prog2);
+      expect(mat.setAttribute(prog2)).toBe(false);
+      expect(mat.shaderProgram()).toBe(prog2);
+    });
+    it('uniform', function () {
+      var prog = mat.shaderProgram(),
+          uni = new vgl.floatUniform('aspect', 1.0);
+      expect(mat.uniform('aspect')).toBe(null);
+      prog.addUniform(uni);
+      expect(mat.uniform('aspect')).toBe(uni);
+    });
+    it('bind', function () {
+      mockVGLRenderer();
+      var viewer = vgl.viewer($('<canvas/>')[0]);
+      viewer.init();
+      var renderer = viewer.renderWindow().activeRenderer(),
+          mapper = vgl.mapper(),
+          geom = vgl.geometryData(),
+          data = vgl.vertexAttribute('data'),
+          prog = mat.shaderProgram(),
+          sourceData = vgl.sourceDataAnyfv(
+            2, vgl.vertexAttributeKeysIndexed.One, {'name': 'data'});
+      prog.addVertexAttribute(data, vgl.vertexAttributeKeysIndexed.One);
+      geom.addSource(sourceData);
+      mapper.setGeometryData(geom);
+      renderState = new vgl.renderState();
+      renderState.m_renderer = renderer;
+      renderState.m_context = renderer.renderWindow().context();
+      renderState.m_mapper = mapper;
+      renderState.m_material = mat;
+      glCounts = $.extend({}, vgl.mockCounts());
+      mat.bind(renderState);
+      expect(vgl.mockCounts().bindTexture).toBe((glCounts.bindTexture || 0) + 6);
+    });
+    it('unbind', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      mat.undoBind(renderState);
+      expect(vgl.mockCounts().bindTexture).toBe((glCounts.bindTexture || 0) + 2);
+    });
+    it('bindVertexData', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      mat.bindVertexData(renderState, 1);
+      expect(vgl.mockCounts().enableVertexAttribArray).toBe((glCounts.enableVertexAttribArray || 0) + 1);
+      mat.bindVertexData(renderState, 'not an attrib');
+      expect(vgl.mockCounts().enableVertexAttribArray).toBe((glCounts.enableVertexAttribArray || 0) + 1);
+    });
+    it('undoBindVertexData', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      mat.undoBindVertexData(renderState, 1);
+      expect(vgl.mockCounts().disableVertexAttribArray).toBe((glCounts.disableVertexAttribArray || 0) + 1);
+      mat.undoBindVertexData(renderState, 'not an attrib');
+      expect(vgl.mockCounts().disableVertexAttribArray).toBe((glCounts.disableVertexAttribArray || 0) + 1);
+    });
+  });
+  describe('Private methods', function () {
+    it('_setup', function () {
+      var mat = vgl.material();
+      expect(mat._setup()).toBe(false);
+    });
+    it('_cleanup', function () {
+      mockVGLRenderer();
+      var mat = vgl.material(), glCounts, renderState;
+
+      var viewer = vgl.viewer($('<canvas/>')[0]);
+      viewer.init();
+      var renderer = viewer.renderWindow().activeRenderer();
+      renderState = new vgl.renderState();
+      renderState.m_renderer = renderer;
+      renderState.m_context = renderer.renderWindow().context();
+      var blend = new vgl.blend(),
+          tex = new vgl.texture(),
+          prog = new vgl.shaderProgram();
+      mat.addAttribute(blend);
+      mat.addAttribute(tex);
+      mat.setAttribute(prog);
+      glCounts = $.extend({}, vgl.mockCounts());
+      mat._cleanup(renderState);
+      expect(vgl.mockCounts().deleteProgram).toBe((glCounts.deleteProgram || 0) + 1);
+    });
+  });
+});

--- a/testing/cases/phantomjs/shaderProgram.js
+++ b/testing/cases/phantomjs/shaderProgram.js
@@ -1,0 +1,212 @@
+/* global describe, it, expect, vgl, mockVGLRenderer, getBaseUrl */
+
+describe('vgl.shaderProgram', function () {
+  describe('Create', function () {
+    it('create function', function () {
+      var sp = vgl.shaderProgram();
+      expect(sp instanceof vgl.shaderProgram).toBe(true);
+    });
+  });
+  describe('Public methods', function () {
+    var sp, renderState, glCounts;
+    var vertexShaderSource = 'varying vec4 color; void main () { gl_FragColor = colorVar; }';
+    it('loadFromFile and loadShader', function () {
+      sp = vgl.shaderProgram();
+      /* Temporarily reroute $.ajax so we can test our function */
+      var ajax = $.ajax, results;
+      $.ajax = function (opts) {
+        opts.success(opts.url);
+        results = opts;
+      };
+      expect(sp.loadFromFile(vgl.GL.FRAGMENT_SHADER, 'testurl')).toBe(true);
+      expect(results.url).toBe('testurl');
+      expect(sp.loadShader(vgl.GL.FRAGMENT_SHADER, 'filename')).toBe(true);
+      expect(results.url).toBe(getBaseUrl() + '/shaders/filename');
+      $.ajax = ajax;
+      expect(sp.loadFromFile(vgl.GL.FRAGMENT_SHADER, 'not a url')).toBe(false);
+      expect(sp.loadShader(vgl.GL.FRAGMENT_SHADER, 'filename')).toBe(false);
+    });
+    it('queryUniformLocation and addVertexAttribute', function () {
+      mockVGLRenderer();
+      var viewer = vgl.viewer($('<canvas/>')[0]);
+      viewer.init();
+      var renderer = viewer.renderWindow().activeRenderer(),
+          mapper = vgl.mapper(),
+          material = vgl.material(),
+          geom = vgl.geometryData(),
+          data = vgl.vertexAttribute('data'),
+          sourceData = vgl.sourceDataAnyfv(
+            2, vgl.vertexAttributeKeysIndexed.One, {'name': 'data'});
+      // addVertexAttribute doesn't return anything, so this just exercises the
+      // code without any further test.
+      sp.addVertexAttribute(data, vgl.vertexAttributeKeysIndexed.One);
+      material.addAttribute(sp);
+      geom.addSource(sourceData);
+      mapper.setGeometryData(geom);
+      renderState = new vgl.renderState();
+      renderState.m_renderer = renderer;
+      renderState.m_context = renderer.renderWindow().context();
+      renderState.m_mapper = mapper;
+      renderState.m_material = material;
+      var mvi = new vgl.modelViewUniform('modelViewMatrix');
+      glCounts = $.extend({}, vgl.mockCounts());
+      // mock VGL just increments the location each time
+      expect(sp.queryUniformLocation(renderState, mvi)).toBe(1);
+      expect(vgl.mockCounts().getUniformLocation).toBe((glCounts.getUniformLocation || 0) + 1);
+      expect(sp.queryUniformLocation(renderState, mvi)).toBe(2);
+      expect(vgl.mockCounts().getUniformLocation).toBe((glCounts.getUniformLocation || 0) + 2);
+    });
+    it('queryAttributeLocation', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      // mock VGL just increments the location each time
+      expect(sp.queryAttributeLocation(renderState, 'name1')).toBe(3);
+      expect(vgl.mockCounts().getAttribLocation).toBe((glCounts.getAttribLocation || 0) + 1);
+      expect(sp.queryAttributeLocation(renderState, 'name2')).toBe(4);
+      expect(vgl.mockCounts().getAttribLocation).toBe((glCounts.getAttribLocation || 0) + 2);
+    });
+    it('addShader', function () {
+      var shader1 = vgl.shader(vgl.GL.FRAGMENT_SHADER),
+          shader2 = vgl.shader(vgl.GL.VERTEX_SHADER),
+          shader3 = vgl.shader(vgl.GL.FRAGMENT_SHADER);
+      shader1.setShaderSource(vertexShaderSource);
+      expect(sp.addShader(shader1)).toBe(true);
+      expect(sp.addShader(shader1)).toBe(false);
+      expect(sp.addShader(shader2)).toBe(true);
+      expect(sp.addShader(shader1)).toBe(false);
+      expect(sp.addShader(shader3)).toBe(true);
+      expect(sp.addShader(shader1)).toBe(true);
+    });
+    it('addUniform and uniform', function () {
+      var mvi = new vgl.modelViewUniform('modelViewMatrix'),
+          floatuni = new vgl.floatUniform('aspect', 1.0);
+      expect(sp.addUniform(mvi)).toBe(true);
+      expect(sp.addUniform(mvi)).toBe(false);
+      expect(sp.uniform('aspect')).toBe(null);
+      expect(sp.addUniform(floatuni)).toBe(true);
+      expect(sp.uniform('aspect')).toBe(floatuni);
+    });
+    it('uniformLocation, bindUniforms, and updateUniforms', function () {
+      expect(sp.uniformLocation('aspect')).toBe(undefined);
+      sp.bindUniforms(renderState);
+      var val = sp.uniformLocation('aspect');
+      expect(val).toBeGreaterThan(1);
+      sp.bindUniforms(renderState);
+      expect(sp.uniformLocation('aspect')).toBeGreaterThan(val);
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.updateUniforms(renderState);
+      expect(vgl.mockCounts().uniform1fv).toBe((glCounts.uniform1fv || 0) + 1);
+      expect(vgl.mockCounts().uniformMatrix4fv).toBe((glCounts.uniformMatrix4fv || 0) + 1);
+    });
+    it('attributeLocation and bindAttributes', function () {
+      var posAttr = vgl.vertexAttribute('pos'),
+          clrAttr = vgl.vertexAttribute('color');
+      expect(sp.attributeLocation('color')).toBe(undefined);
+      sp.addVertexAttribute(posAttr, vgl.vertexAttributeKeys.Position);
+      sp.addVertexAttribute(clrAttr, vgl.vertexAttributeKeysIndexed.One);
+      expect(sp.attributeLocation('color')).toBe(undefined);
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.bindAttributes(renderState);
+      expect(vgl.mockCounts().bindAttribLocation).toBe((glCounts.bindAttribLocation || 0) + 2);
+      expect(sp.attributeLocation('pos')).toBe('0');
+      expect(sp.attributeLocation('color')).toBe('1');
+      // we added data earlier and repalced it with color
+      expect(sp.attributeLocation('data')).toBe(undefined);
+    });
+    it('link', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      expect(sp.link(renderState)).toBe(true);
+      expect(vgl.mockCounts().linkProgram).toBe((glCounts.linkProgram || 0) + 1);
+      var oldGPP = renderState.m_context.getProgramParameter;
+      renderState.m_context.getProgramParameter = function () { };
+      expect(sp.link(renderState)).toBe(false);
+      renderState.m_context.getProgramParameter = oldGPP;
+    });
+    it('use', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.use(renderState);
+      expect(vgl.mockCounts().useProgram).toBe((glCounts.useProgram || 0) + 1);
+    });
+    it('deleteProgram', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.deleteProgram(renderState);
+      expect(vgl.mockCounts().deleteProgram).toBe((glCounts.deleteProgram || 0) + 1);
+    });
+    it('deleteVertexAndFragment', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.deleteVertexAndFragment(renderState);
+      expect(vgl.mockCounts().deleteShader).toBe((glCounts.deleteShader || 0) + 3);
+    });
+    it('compileAndLink', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.compileAndLink(renderState);
+      expect(vgl.mockCounts().attachShader).toBe((glCounts.attachShader || 0) + 3);
+      sp.compileAndLink(renderState);
+      expect(vgl.mockCounts().attachShader).toBe((glCounts.attachShader || 0) + 3);
+      var oldGPP = renderState.m_context.getProgramParameter;
+      renderState.m_context.getProgramParameter = function () { };
+      sp.modified();
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.compileAndLink(renderState);
+      renderState.m_context.getProgramParameter = oldGPP;
+      expect(vgl.mockCounts().deleteProgram).toBe((glCounts.deleteProgram || 0) + 1);
+    });
+    it('bind', function () {
+      sp.modified();
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.bind(renderState);
+      expect(vgl.mockCounts().attachShader).toBe((glCounts.attachShader || 0) + 3);
+      expect(vgl.mockCounts().uniform1fv).toBe((glCounts.uniform1fv || 0) + 1);
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.bind(renderState);
+      expect(vgl.mockCounts().attachShader).toBe(glCounts.attachShader);
+      expect(vgl.mockCounts().uniform1fv).toBe((glCounts.uniform1fv || 0) + 1);
+    });
+    it('undoBind', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.undoBind(renderState);
+      expect(vgl.mockCounts().useProgram).toBe((glCounts.useProgram || 0) + 1);
+    });
+    it('bindVertexData', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.bindVertexData(renderState, '1');
+      expect(vgl.mockCounts().vertexAttribPointer).toBe((glCounts.vertexAttribPointer || 0) + 1);
+      expect(vgl.mockCounts().enableVertexAttribArray).toBe((glCounts.enableVertexAttribArray || 0) + 1);
+      sp.bindVertexData(renderState, 'not an attrib');
+      expect(vgl.mockCounts().vertexAttribPointer).toBe((glCounts.vertexAttribPointer || 0) + 1);
+      expect(vgl.mockCounts().enableVertexAttribArray).toBe((glCounts.enableVertexAttribArray || 0) + 1);
+    });
+    it('undoBindVertexData', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp.undoBindVertexData(renderState, '1');
+      expect(vgl.mockCounts().disableVertexAttribArray).toBe((glCounts.disableVertexAttribArray || 0) + 1);
+      sp.undoBindVertexData(renderState, 'not an attrib');
+      expect(vgl.mockCounts().disableVertexAttribArray).toBe((glCounts.disableVertexAttribArray || 0) + 1);
+    });
+  });
+  describe('Private methods', function () {
+    it('_setup and _cleanup', function () {
+      mockVGLRenderer();
+      var sp = vgl.shaderProgram(), glCounts, renderState;
+      var viewer = vgl.viewer($('<canvas/>')[0]);
+      viewer.init();
+      var renderer = viewer.renderWindow().activeRenderer();
+      renderState = new vgl.renderState();
+      renderState.m_renderer = renderer;
+      renderState.m_context = renderer.renderWindow().context();
+      glCounts = $.extend({}, vgl.mockCounts());
+      sp._setup(renderState);
+      expect(vgl.mockCounts().createProgram).toBe((glCounts.createProgram || 0) + 1);
+      sp._setup(renderState);
+      expect(vgl.mockCounts().createProgram).toBe((glCounts.createProgram || 0) + 1);
+      sp._cleanup(renderState);
+      sp._setup(renderState);
+      expect(vgl.mockCounts().createProgram).toBe((glCounts.createProgram || 0) + 2);
+    });
+  });
+  describe('Global functions', function () {
+    it('getBaseUrl', function () {
+      /* In our test environment, this is the empty string. */
+      expect(getBaseUrl()).toBe('');
+    });
+  });
+});

--- a/testing/js/testUtils.js
+++ b/testing/js/testUtils.js
@@ -140,12 +140,14 @@ function mockVGLRenderer() {
     deleteShader: noop('deleteShader'),
     deleteTexture: noop('deleteTexture'),
     depthFunc: noop('depthFunc'),
+    detachShader: noop('detachShader'),
     disable: noop('disable'),
     disableVertexAttribArray: noop('disableVertexAttribArray'),
     drawArrays: noop('drawArrays'),
     enable: noop('enable'),
     enableVertexAttribArray: noop('enableVertexAttribArray'),
     finish: noop('finish'),
+    getAttribLocation: incID('getAttribLocation'),
     getExtension: incID('getExtension'),
     getParameter: function (key) {
       count('getParameter');


### PR DESCRIPTION
If we are rendering multiple features in the same context, we must unbind the vertex data to make sure the next feature has a known state.

This fixes a bug in `material.undoBindVertexData` where it never worked.

This also adds units tests for shaderProgram, material, and mapper.  In adding those tests, this fixes a bug in shaderProgram:  `addShader` never deleted the previous shader of the same type (calling it with two vertex shaders should only keep that shader).  This fixes bugs in material: the `exists` function always returned false because it used different keys than `addAttribute` and `setAttribute`.  The `attribute` function never worked for texture attributes.  `setAttribute` could do strange things when asking to set a texture attribute that was already set.