### PR TITLE
Don't draw zero-length buffers.

### DIFF
--- a/src/mapper.js
+++ b/src/mapper.js
@@ -302,10 +302,12 @@ vgl.mapper = function (arg) {
     }
 
     noOfPrimitives = m_geomData.numberOfPrimitives();
-    for (j = 0; j < noOfPrimitives; j += 1) {
-      m_context.bindBuffer(vgl.GL.ARRAY_BUFFER, m_buffers[bufferIndex]);
-      bufferIndex += 1;
+    for (j = 0; j < noOfPrimitives; j += 1, bufferIndex += 1) {
       primitive = m_geomData.primitive(j);
+      if (!primitive.numberOfIndices()) {
+        continue;
+      }
+      m_context.bindBuffer(vgl.GL.ARRAY_BUFFER, m_buffers[bufferIndex]);
       switch (primitive.primitiveType()) {
         case vgl.GL.POINTS:
           m_context.drawArrays(vgl.GL.POINTS, 0, primitive.numberOfIndices());

--- a/testing/cases/phantomjs/mapper.js
+++ b/testing/cases/phantomjs/mapper.js
@@ -128,6 +128,14 @@ describe('vgl.mapper', function () {
       mapper.geometryData().addSource(src2);
       mapper.modified();
       mapper.render(renderState);
+
+      /* Zero length indices shouldn't generate drawArray calls */
+      line.setIndices([]);
+      point.setIndices([]);
+      glCounts = $.extend({}, vgl.mockCounts());
+      mapper.modified();
+      mapper.render(renderState);
+      expect(vgl.mockCounts().drawArrays).toBe((glCounts.drawArrays || 0) + 3);
     });
     it('deleteVertexBufferObjects', function () {
       mapper.render(renderState);


### PR DESCRIPTION
Doing so emits a GL error, and it is useful to allow them.  For instance, a degenerate polygon can result in zero triangles.